### PR TITLE
feat(logger): define log for each service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -143,7 +143,7 @@ func main() {
 
 	// this logger is main log for both admin api and application logging
 	// proxy/r,w gets own logger
-	logger, err := logManager.GetLogger("main")
+	logger, err := logManager.GetLogger("terraster")
 	if err != nil {
 		log.Fatalf("Failed to get logger: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unkn0wn-root/terraster
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,7 @@ type Service struct {
 	HealthCheck  *HealthCheckConfig `yaml:"health_check,omitempty"` // Optional Per-Service Health Check
 	Middleware   []Middleware       `yaml:"middleware"`             // Middleware configurations specific to the service.
 	Locations    []Location         `yaml:"locations"`              // Routing paths and backend configurations for the service.
+	LogName      string             `yaml:"log_name,omitempty"`     // Name of the logger to use for this service.
 }
 
 // Middleware defines the configuration for various middleware components.

--- a/internal/server/middlewares.go
+++ b/internal/server/middlewares.go
@@ -15,7 +15,7 @@ func (s *Server) createServiceMiddleware(svc *service.ServiceInfo) http.Handler 
 	baseHandler := http.HandlerFunc(s.handleRequest)
 
 	chain := middleware.NewMiddlewareChain()
-	chain.AddConfiguredMiddlewares(s.config, s.logger)
+	chain.AddConfiguredMiddlewares(s.config, svc.Logger)
 
 	// Check if the service has any specific middleware configurations to override or add.
 	if svc.Middleware != nil {
@@ -61,14 +61,9 @@ func (s *Server) createServiceMiddleware(svc *service.ServiceInfo) http.Handler 
 		}
 	}
 
-	// Retrieve a logger specifically for request logging.
-	requestsLogger, err := s.logManager.GetLogger("requests")
-	if err != nil {
-		s.logger.Error("Failed to get requests logger", zap.Error(err))
-	}
-
+	// add logging middleware to the chain with service logger
 	logger := middleware.NewLoggingMiddleware(
-		requestsLogger,
+		svc.Logger,
 		middleware.WithLogLevel(zap.InfoLevel), // Set the logging level to Info.
 		middleware.WithHeaders(),               // Configure the middleware to log HTTP headers.
 		middleware.WithQueryParams(),           // Configure the middleware to log query parameters.

--- a/log.config.json
+++ b/log.config.json
@@ -1,8 +1,8 @@
 {
   "loggers": {
-    "main": {
+    "terraster": {
       "level": "debug",
-      "outputPaths": ["app.log"],
+      "outputPaths": ["terraster.log"],
       "errorOutputPaths": ["stderr"],
       "development": true,
       "logToConsole": true,
@@ -22,23 +22,12 @@
         "timeEncoder": "iso8601",
         "durationEncoder": "string",
         "callerEncoder": "short"
-      },
-      "logRotation": {
-        "enabled": true,
-        "maxSizeMB": 50,
-        "maxBackups": 7,
-        "maxAgeDays": 30,
-        "compress": true
-      },
-      "sanitization": {
-        "sensitiveFields": ["password", "token", "access_token", "refresh_token"],
-        "mask": "****"
       }
     },
-    "request": {
+    "service_default": {
       "level": "info",
-      "outputPaths": ["request.log"],
-      "errorOutputPaths": ["stderr"],
+      "outputPaths": ["service_default.log"],
+      "errorOutputPaths": ["service_default_error.log"],
       "development": false,
       "logToConsole": false,
       "sampling": {

--- a/pkg/logger/manager.go
+++ b/pkg/logger/manager.go
@@ -14,7 +14,6 @@ type LoggerManager struct {
 }
 
 func NewLoggerManager(logsConfigPath string) (*LoggerManager, error) {
-
 	lm := &LoggerManager{
 		loggers:       make(map[string]*zap.Logger),
 		defaultConfig: &DefaultConfig,


### PR DESCRIPTION
Since every request can be logged via load balancer, we need to have ability to define logs for each service to be able to diffirenciate between services. We now can define our own log section in log.config.json file